### PR TITLE
chore: don't pin builder image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/alpine:latest@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412 AS builder
+FROM docker.io/library/alpine:latest AS builder
 
 RUN apk add --no-cache curl jq zstd tar coreutils
 


### PR DESCRIPTION
cuts down on unnecessary renovate spam