### PR TITLE
chore: cleanup boxbuddy config from /etc/skel

### DIFF
--- a/system_files/shared/etc/skel/.var/app/io.github.dvlv.boxbuddyrs/config/glib-2.0/settings/keyfile
+++ b/system_files/shared/etc/skel/.var/app/io.github.dvlv.boxbuddyrs/config/glib-2.0/settings/keyfile
@@ -1,2 +1,0 @@
-[io/github/dvlv/boxbuddyrs]
-default-terminal='Ptyxis'


### PR DESCRIPTION
we switched to distroshelf a long time ago, will not affect users because skel