### PR TITLE
Revert "fix: aurora-cli install brew stuff"

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/system.just
+++ b/system_files/shared/usr/share/ublue-os/just/system.just
@@ -35,7 +35,6 @@ benchmark:
 [group('System')]
 aurora-cli:
     @/usr/bin/ublue-bling
-    brew bundle --file=/usr/share/ublue-os/homebrew/cli.Brewfile
 
 # alias for install-fonts
 aurora-fonts:


### PR DESCRIPTION
Reverts get-aurora-dev/common#56

Think the cli-name change should handle this now correctly and use the brewfile during the  bling-script