### PR TITLE
fix: set new flag for firefox hardware accel

### DIFF
--- a/system_files/shared/usr/share/ublue-os/firefox-config/01-aurora-global.js
+++ b/system_files/shared/usr/share/ublue-os/firefox-config/01-aurora-global.js
@@ -1,3 +1,3 @@
 // Aurora Global
 pref("gfx.webrender.all", true);
-pref("media.ffmpeg.vaapi.enabled", true);
+pref("media.hardware-video-decoding.force-enabled", true);


### PR DESCRIPTION
See: https://github.com/elFarto/nvidia-vaapi-driver/issues/358#issuecomment-2769502201

<img width="1248" height="339" alt="image" src="https://github.com/user-attachments/assets/74d4893d-0f62-461a-962a-f2a9cbd10cf5" />
