### PR TITLE
docs: update README and AGENTS to reflect Aurora repository structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,81 +1,101 @@
-# Bluefin-Common Copilot Instructions
+# Aurora-Common Copilot Instructions
 
-This document provides essential information for coding agents working with the bluefin-common repository.
+This document provides essential information for coding agents working with the aurora-common repository.
 
 ## Repository Overview
 
-**Bluefin-Common** is a shared OCI layer containing common configuration files used across all Bluefin variants (bluefin, bluefin-dx, bluefin-lts).
+**Aurora-Common** is a shared OCI layer containing configuration files for Aurora and Aurora-DX variants.
 
-- **Type**: Minimal OCI container layer (system files only)
-- **Purpose**: Centralize shared configuration to reduce duplication across bluefin and bluefin-lts
-- **Base**: Built from scratch with COPY directive
+- **Type**: OCI container layer built on top of projectbluefin/common
+- **Purpose**: Provide Aurora-specific configuration and assets while inheriting shared Bluefin configuration
+- **Base**: Multi-stage build pulling from aurora-wallpapers, projectbluefin/common, and local files
 - **Languages**: Configuration files (JSON, shell scripts, markdown)
-- **Build System**: GitHub Actions with podman/buildah
+- **Build System**: GitHub Actions with podman/buildah, Just for local convenience
 
 ## Repository Structure
 
 ### Root Directory Files
-- `Containerfile` - Multi-stage build (scratch → ctx stage with system_files)
-- `cosign.pub` - Container signing public key (shared with bluefin/bluefin-lts)
-- `README.md` - Basic repository description
+- `Containerfile` - Multi-stage build pulling wallpapers, projectbluefin/common, and local files
+- `Justfile` - Convenience commands for building and inspecting the image
+- `cosign.pub` - Container signing public key
+- `image-versions.yml` - Version tracking for dependencies
+- `README.md` - Repository documentation
+- `.pre-commit-config.yaml` - Pre-commit hooks configuration
 
 ### Key Directories
-- `system_files/` - All configuration files that get copied into bluefin images
-  - `etc/ublue-os/` - System configuration files (bling.json, fastfetch.json, setup.json)
-  - `usr/share/ublue-os/` - User-space configurations
-    - `firefox-config/` - Firefox default settings
-    - `flatpak-overrides/` - Flatpak app overrides
-    - `just/` - Just recipe additions
-    - `motd/` - Message of the day templates and tips
-    - `privileged-setup.hooks.d/` - Privileged setup hooks
-    - `system-setup.hooks.d/` - System setup hooks
-    - `user-setup.hooks.d/` - User setup hooks
+- `system_files/` - Configuration files organized by variant
+  - `shared/` - Configuration shared between Aurora and Aurora-DX
+    - `etc/` - System-level configuration (bazaar, dconf, geoclue, profile.d, skel, systemd, ublue-os, zsh)
+    - `usr/` - User-space configuration (bin, lib, libexec, share)
+  - `dx/` - Aurora-DX specific configuration
+    - `etc/` - DX system-level configuration
+    - `usr/` - DX user-space configuration
+- `flatpaks/` - Flatpak definitions for Aurora images
+- `logos/` - Aurora branding and logo assets
 
 ### GitHub Actions
-- `.github/workflows/build.yml` - Simple build workflow using podman/buildah
+- `.github/workflows/build.yml` - Build workflow using podman/buildah
 
 ## Build Instructions
 
 ### Prerequisites
-This repository requires minimal tooling:
-- **podman** and **buildah** (usually pre-installed on development systems)
-- No Just, no pre-commit, no complex build dependencies
+- **podman** and **buildah** for building containers
+- **just** for convenience commands (optional)
+- **pre-commit** for development hooks (optional)
 
 ### Build Commands
 
 **Build locally:**
 ```bash
-# Build the container
-buildah build -t bluefin-common:latest -f ./Containerfile .
+# Using Just
+just build
 
-# Inspect the built image
-podman images bluefin-common
+# Or directly with podman
+podman build -t localhost/aurora-common:latest -f ./Containerfile .
 ```
 
-**Test the image:**
+**Inspect the image:**
 ```bash
-# Copy files from the container to verify structure
-podman create --name test bluefin-common:latest
-podman cp test:/system_files ./test-output
-podman rm test
-tree ./test-output
+# View directory structure
+just tree
+
+# Dump all contents to ./dump directory
+just dump
+```
+
+**Validate Just syntax:**
+```bash
+# Check syntax
+just check
+
+# Fix formatting
+just fix
 ```
 
 ### Build Process
-1. GitHub Actions triggers on push to main or PR
-2. `buildah build` creates image from `Containerfile`
-3. Image is pushed to `ghcr.io/projectbluefin/bluefin-common:latest`
-4. Bluefin and bluefin-lts reference this image with `COPY --from=ghcr.io/ublue-os/bluefin-common:latest`
+1. Builder stage pulls aurora-wallpapers and processes them
+2. Scratch stage pulls projectbluefin/common shared files
+3. Local files (flatpaks, logos, system_files) are added
+4. Final image is pushed to `ghcr.io/ublue-os/aurora-common:latest`
+5. Aurora and Aurora-DX images reference this layer in their builds
 
 ## Usage in Downstream Projects
 
-Bluefin and bluefin-lts use this layer in their Containerfiles:
+Aurora images use this layer in their Containerfiles:
 
 ```dockerfile
-FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
+FROM ghcr.io/ublue-os/aurora-common:latest AS aurora-common
 
-# Later in the build:
-COPY --from=bluefin-common /system_files /desired/destination
+# Copy shared configuration
+COPY --from=aurora-common /system_files/shared /
+
+# Aurora-DX also copies DX-specific configuration
+COPY --from=aurora-common /system_files/dx /
+
+# Copy wallpapers and other assets
+COPY --from=aurora-common /wallpapers /
+COPY --from=aurora-common /flatpaks /tmp/flatpaks
+COPY --from=aurora-common /logos /tmp/logos
 ```
 
 ## Making Changes
@@ -83,72 +103,83 @@ COPY --from=bluefin-common /system_files /desired/destination
 ### Modifying Configuration Files
 
 1. **Edit files in `system_files/`** - Maintain the existing directory structure
-2. **Test locally** with buildah to ensure no syntax errors
+2. **Test locally** with `just build` to ensure no syntax errors
 3. **Create PR** - GitHub Actions will build and validate
 
 ### Adding New Configuration Files
 
-1. Place files in the appropriate subdirectory under `system_files/`
-2. Follow the existing path conventions:
-   - System configs: `system_files/etc/ublue-os/`
-   - User configs: `system_files/usr/share/ublue-os/`
-3. Ensure file permissions are correct (executables for scripts)
+1. Determine if the configuration is shared or DX-specific
+2. Place files in the appropriate subdirectory:
+   - Shared configs: `system_files/shared/`
+   - DX-specific: `system_files/dx/`
+3. Follow the existing path structure (etc/ or usr/)
+4. Ensure file permissions are correct (executables for scripts)
 
 ### Common Modification Patterns
-- **Firefox configs**: Edit `system_files/usr/share/ublue-os/firefox-config/`
-- **Setup hooks**: Modify scripts in `system_files/usr/share/ublue-os/*-setup.hooks.d/`
-- **System settings**: Update JSON files in `system_files/etc/ublue-os/`
-- **Just recipes**: Add/modify `.just` files in `system_files/usr/share/ublue-os/just/`
+- **Shared system configs**: Edit files in `system_files/shared/etc/`
+- **Shared user configs**: Edit files in `system_files/shared/usr/`
+- **DX-specific configs**: Edit files in `system_files/dx/`
+- **Flatpak definitions**: Modify `flatpaks/` directory
+- **Branding assets**: Update `logos/` directory
 
 ## Validation
 
 ### Manual Validation
 ```bash
-# Check Containerfile syntax
-buildah build --dry-run -f ./Containerfile .
+# Build locally to check for errors
+just build
+
+# Check Just syntax
+just check
 
 # Validate JSON files
 find system_files -name "*.json" -exec sh -c 'echo "Checking {}"; cat {} | jq . > /dev/null' \;
 
 # Check shell script syntax
 find system_files -name "*.sh" -exec bash -n {} \;
+
+# Inspect built image
+just tree
 ```
 
 ### GitHub Actions
 The build workflow automatically:
-- Builds the container with buildah
+- Builds the container with podman/buildah
 - Pushes to GHCR on merge to main
 - Validates build succeeds on PRs
 
 ## Development Guidelines
 
 ### Making Changes
-1. **Keep it simple** - This repo contains only configuration files
+1. **Understand shared vs DX** - Place configs in the correct system_files subdirectory
 2. **Maintain structure** - Follow existing directory patterns
-3. **Test locally** - Build with buildah before pushing
-4. **No complex dependencies** - This is intentionally minimal
+3. **Test locally** - Build with `just build` before pushing
+4. **Use pre-commit hooks** - Run before committing if configured
 
 ### File Editing Best Practices
 - **JSON files**: Validate syntax with `jq` before committing
 - **Shell scripts**: Check syntax with `bash -n script.sh`
+- **Just files**: Use `just check` and `just fix` for syntax validation
 - **Keep files small** - Each file should have a single, clear purpose
 - **Document changes** - Update comments in configuration files
 
 ## Trust These Instructions
 
-**This repository is intentionally simple.** It contains only:
-- Configuration files in `system_files/`
-- A minimal Containerfile
-- A simple GitHub Actions workflow
-
-There are no complex build systems, no package management, no multi-stage builds beyond the scratch→ctx pattern.
+**This repository structure:**
+- Configuration files in `system_files/shared/` and `system_files/dx/`
+- Flatpak definitions in `flatpaks/`
+- Branding assets in `logos/`
+- Multi-stage Containerfile pulling from aurora-wallpapers and projectbluefin/common
+- Justfile with convenience commands
+- GitHub Actions workflow for automated builds
 
 ## Other Rules
 
 - Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for all commits and PR titles
 - Keep changes minimal and surgical
-- This layer is used by both bluefin (ublue-os/bluefin) and bluefin-lts (ublue-os/bluefin-lts)
-- Changes here affect all downstream Bluefin variants
+- This layer is used by Aurora and Aurora-DX
+- Changes to `system_files/shared/` affect both variants
+- Changes to `system_files/dx/` only affect Aurora-DX
 
 ## Attribution Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,56 @@
-# WIP - aurora-common
+# aurora-common
 
-Shared OCI layer containing common configuration files used across all Bluefin variants (bluefin, bluefin-dx, bluefin-lts).
+Shared OCI layer containing configuration files for Aurora and Aurora-DX variants.
 
-## What's Inside
+## Repository Structure
 
-This layer contains two main configuration directories:
+This layer builds on top of `ghcr.io/projectbluefin/common` and includes:
 
-### `/etc/ublue-os/` - System Configuration
-- Bling - CLI theming settings
-- Fastfetch settings - System information display configuration
-- Setup configuration - First-boot and system setup parameters
+- `system_files/shared/` - Configuration shared between Aurora and Aurora-DX
+- `system_files/dx/` - Aurora-DX specific configuration
+- `wallpapers/` - Aurora wallpapers from aurora-wallpapers repository
+- `flatpaks/` - Flatpak definitions
+- `logos/` - Aurora branding assets
 
-### `/usr/share/ublue-os/` - User-Space Configuration
-- Firefox defaults - Pre-configured Firefox settings
-- Flatpak overrides - Application-specific Flatpak configurations
-- Just recipes - Additional command recipes for system management
-- MOTD templates - Message of the day and tips
-- Setup hooks - Scripts for privileged, system, and user setup stages
+## Usage in Downstream Projects
 
-## Usage in Containerfile
-
-Reference this layer as a build stage and copy the directories you need:
-
-### Copy everything:
-```dockerfile
-FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
-
-# Copy all system files
-COPY --from=bluefin-common /system_files /
-```
-
-### Copy only system configuration:
-
-This is what Aurora should use, gives shares the common set of files and keeps the images opinions seperate.
+Aurora images reference this layer in their Containerfiles:
 
 ```dockerfile
-FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
+FROM ghcr.io/ublue-os/aurora-common:latest AS aurora-common
 
-# Copy only /etc configuration
-COPY --from=bluefin-common /system_files/etc /etc
-```
+# Copy shared configuration
+COPY --from=aurora-common /system_files/shared /
 
-### Copy only the image opinion:
-```dockerfile
-FROM ghcr.io/ublue-os/bluefin-common:latest AS bluefin-common
+# Copy DX-specific configuration (Aurora-DX only)
+COPY --from=aurora-common /system_files/dx /
 
-# Copy only /usr/share configuration
-COPY --from=bluefin-common /system_files/usr /usr
+# Copy wallpapers
+COPY --from=aurora-common /wallpapers /
+
+# Copy other assets as needed
+COPY --from=aurora-common /flatpaks /tmp/flatpaks
+COPY --from=aurora-common /logos /tmp/logos
 ```
 
 ## Building Locally
 
 ```bash
 just build
+```
+
+## Additional Commands
+
+```bash
+# Check Just syntax
+just check
+
+# Fix Just formatting
+just fix
+
+# Inspect image structure
+just tree
+
+# Dump image contents to ./dump
+just dump
 ```


### PR DESCRIPTION
Updates documentation to accurately reflect the aurora-common repository:

- Changed from bluefin-common to aurora-common references
- Updated structure to reflect system_files/shared and system_files/dx layout
- Added wallpapers, flatpaks, and logos to documentation
- Included Justfile commands for local development
- Clarified multi-stage build process with projectbluefin/common dependency

Resolves outdated references to Bluefin-specific paths and structure.