### PR TITLE
fix: disable confusing kde updates page

### DIFF
--- a/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/kdeglobals
+++ b/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/kdeglobals
@@ -13,3 +13,6 @@ font=Noto Sans,10,-1,5,50,0,0,0,0,0
 menuFont=Noto Sans,10,-1,5,50,0,0,0,0,0
 smallestReadableFont=Noto Sans,8,-1,5,50,0,0,0,0,0
 toolBarFont=Noto Sans,9,-1,5,50,0,0,0,0,0
+
+[KDE Control Module Restrictions][$i]
+kcm_updates=false


### PR DESCRIPTION
This controls plasma discover behavior, which we don't expose to users by default and will be gone soon anyway. This is confusing as we also offer our own settings module which controls system updates.

Fixes: https://github.com/ublue-os/aurora/issues/853


<img width="321" height="319" alt="image" src="https://github.com/user-attachments/assets/5d0fe2e5-7101-40d1-b0e6-f5aa2ffe9338" />
