### PR TITLE
chore(just): hide toggle software-store

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/system.just
+++ b/system_files/shared/usr/share/ublue-os/just/system.just
@@ -390,7 +390,7 @@ setup-sunshine ACTION="":
 
 # Toggle between Bazaar and Discover software stores
 [group('Apps')]
-toggle-software-store ACTION="":
+_toggle-software-store ACTION="":
     #!/usr/bin/env bash
     source /usr/lib/ujust/ujust.sh
 


### PR DESCRIPTION
We will be removing discover in spring 2026 with Fedora 44. This makes sure no one enables it anymore, but still leaves the option to change their mind when they have previously chosen discover.