### PR TITLE
chore: remove inotify.conf

### DIFF
--- a/system_files/shared/usr/lib/sysctl.d/80-inotify.conf
+++ b/system_files/shared/usr/lib/sysctl.d/80-inotify.conf
@@ -1,2 +1,0 @@
-fs.inotify.max_user_instances=8192
-fs.inotify.max_user_watches=524288


### PR DESCRIPTION
introduced in https://github.com/ublue-os/bluefin/pull/659

supposed to fix: https://github.com/ublue-os/bluefin/issues/656

We don't need this because this limit is now in ublue-os/brew directly https://github.com/ublue-os/brew/blob/a7fbd884e7a21bf75cb57686f6cd3a5bbc7fe60b/system_files/etc/security/limits.d/30-brew-limits.conf