### PR TITLE
chore(bluefin, pmcd): do not include tmpfiles entry for /var/log pmcd

### DIFF
--- a/system_files/shared/usr/lib/tmpfiles.d/pmcd.conf
+++ b/system_files/shared/usr/lib/tmpfiles.d/pmcd.conf
@@ -1,1 +1,0 @@
-d /var/log/pcp/pmcd - - - -


### PR DESCRIPTION
We do not need this (apparently), and this should be fixed on upstream packaging instead of us carying this file

Related: ublue-os/bluefin#953

copied from:
https://github.com/projectbluefin/common/pull/101/changes/1018a35310fb27b140990ad5b4ef44052aae10d1