### PR TITLE
chore: remove neofetch aliases

### DIFF
--- a/system_files/shared/etc/profile.d/neofetch.sh
+++ b/system_files/shared/etc/profile.d/neofetch.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-alias neofetch=fastfetch

--- a/system_files/shared/usr/share/fish/vendor_conf.d/neofetch.fish
+++ b/system_files/shared/usr/share/fish/vendor_conf.d/neofetch.fish
@@ -1,4 +1,0 @@
-#!/usr/bin/fish
-#shellcheck disable=all
-
-alias neofetch=fastfetch


### PR DESCRIPTION
This is already defined in ublue-fastfetch which we get from bluefin. Fish alias is fine to remove as well for exactly the same reason.

Tested by removing the files and spawning a login shell with fish and running neofetch and it works as expected.

https://github.com/projectbluefin/common/blob/bf18df7ce7d2276587f1137f258b49ada6d833c4/system_files/shared/etc/profile.d/ublue-fastfetch.sh