### PR TITLE
Add org.torproject.torbrowser-launcher to bazaar's blocklist.yml

### DIFF
--- a/system_files/shared/etc/bazaar/blocklist.yaml
+++ b/system_files/shared/etc/bazaar/blocklist.yaml
@@ -34,4 +34,5 @@ blocklists:
     - org.kde.konsole
     - org.kde.kwalletmanager
     - org.kde.kwalletmanager5
+    - org.torproject.torbrowser-launcher
     - org.vim.Vim


### PR DESCRIPTION
The flatpak version of tor browser launcher downloads and runs tor browser within flatpak's sandbox. while this is intended behaviour, it also harms the security posture of tor browser by restricting its abiility to access user namespaces, which means it cannot sandbox individual sites nearly as effectively as it could otherwise. 

While  also true for firefox and other firefox-based browsers as well (chromium based browsers generally ship with zypak as a workaround for this issue), it is especially problematic for tor browser since the people using it often need the absolute best anonymity they can get. To this end, tor browser will actually show a warning that the user is less protected when using a flatpak'd version of their browser, shown below.

<img width="2896" height="2050" alt="image" src="https://github.com/user-attachments/assets/ef801716-6cae-4c3d-b8c3-7fcf1f9e5b49" />

Considering there is an alternative official option for installing tor browser on immutable systems that lacks this issue - the portable package distributed on the tor project's website - I think it's for the best to add tor browser launcher to Aurora's (and Bluefin's) blocklist to hide this footgun from users.