### PR TITLE
chore: add net.mullvad.MullvadBrowser to bazaar blocklist

### DIFF
--- a/system_files/shared/etc/bazaar/blocklist.yaml
+++ b/system_files/shared/etc/bazaar/blocklist.yaml
@@ -24,6 +24,7 @@ blocklists:
     - io.github.kolunmi.Bazaar
     - io.github.zyedidia.micro
     - io.neovim.nvim
+    - net.mullvad.MullvadBrowser
     - org.freedesktop.fwupd
     - org.gnu.emacs
     - org.kde.ark
@@ -34,6 +35,5 @@ blocklists:
     - org.kde.konsole
     - org.kde.kwalletmanager
     - org.kde.kwalletmanager5
-    - net.mullvad.MullvadBrowser
     - org.torproject.torbrowser-launcher
     - org.vim.Vim


### PR DESCRIPTION
Mullvad Browser needs to be blocklisted as well by the same reasons why Tor Browser Launcher was blocklisted.

<img width="1067" height="56" alt="image" src="https://github.com/user-attachments/assets/7e069bcc-71fb-4956-8627-bb10e8d7960d" />

While it doesn't show this warning like it did several months ago, it still suffers from Flatpak's sandbox restrictions as other browsers and it may harm the privacy of end user who chooses to use it.

An alternative to Flatpak variant would be downloading portable installation from their website, just like how you would download Tor Browser, and optionally run their .desktop executable with `--register-app` to add it to app list.

Related PR: #91