### PR TITLE
fix(rebase-helper): refactor rebase-helper script and add support for nvidia

### DIFF
--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -6,7 +6,7 @@ IMAGE_TAG="$(jq -r '."image-tag"' < "$IMAGE_INFO")"
 IMAGE_VENDOR="$(jq -r '."image-vendor"' < "$IMAGE_INFO")"
 IMAGE_REGISTRY="ghcr.io/${IMAGE_VENDOR}"
 
-set -x
+set -euo pipefail
 
 function list_tags() {
   local filter="$1"


### PR DESCRIPTION
Adds support for nvidia images to rebase helper

Tested and works
<img width="461" height="157" alt="image" src="https://github.com/user-attachments/assets/09104ca5-80da-4d62-ac63-0ede4ec46b24" />

Same as https://github.com/projectbluefin/common/pull/162 except the LTS stuff ripped out
