### PR TITLE
fix(fastfetch): update fastfetch config for Plasma 6.6

### DIFF
--- a/system_files/shared/usr/share/ublue-os/fastfetch.jsonc
+++ b/system_files/shared/usr/share/ublue-os/fastfetch.jsonc
@@ -5,7 +5,7 @@
   },
   "general": {
     "dsForceDrm": true
-    },
+  },
   "modules": [
     {
       "type": "title",


### PR DESCRIPTION
current fastfetch crashes on Plasma 6.6, this fixes the issue for the time being. Doesn't cause issues on stable