### PR TITLE
fix: remove dx specific motd

### DIFF
--- a/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
+++ b/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
@@ -16,9 +16,7 @@ Help keep Aurora alive and healthy, consider [donating](https://docs.getaurora.d
 KDE powers your desktop! Donate to [KDE](https://kde.org/donate)
 Like dinosaurs? `ujust toggle-dinosaurs`
 Support the app store! Donate to  [Bazaar](https://github.com/kolunmi/bazaar)!
-Performance profiling tools are built-in: try `sysprof`, `bpftrace`, and other debugging tools
 Switch shells safely: change your shell in [Terminal settings instead of system-wide](https://tim.siosm.fr/blog/2023/12/22/dont-change-defaut-login-shell/)
-VS Code comes with devcontainers extension pre-installed - perfect for containerized development
 Container development is OS-agnostic - your devcontainers work on Linux, macOS, and Windows
 Check out `ujust bbrew` for curated selections of development and command line apps
 Open a folder with Clapgrep (Found in the Bazaar App Store) for super powerful search


### PR DESCRIPTION
This is shown on the regular image which doesn't have these installed and could lead to users thinking they are actually present.

The alternative would be to make a DX specific motd, but the long term goal is to not have DX images at all.