### PR TITLE
fix: kscreenlocker not having a wallpaper

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@ RUN set -xeuo pipefail && \
     REV=3 && \
     ln -sr /out/wallpapers/usr/share/backgrounds/aurora/aurora-wallpaper-"${REV}"/contents/images/3840x2160.jxl /out/wallpapers/usr/share/backgrounds/default.jxl && \
     ln -sr /out/wallpapers/usr/share/backgrounds/aurora/aurora-wallpaper-"${REV}"/contents/images/3840x2160.jxl /out/wallpapers/usr/share/backgrounds/default-dark.jxl && \
-    ln -sr /out/wallpapers/usr/share/backgrounds/aurora/aurora-wallpaper-"${REV}"/contents /out/wallpapers/usr/share/wallpapers/Aurora && \
+    ln -sr /out/wallpapers/usr/share/backgrounds/aurora/aurora-wallpaper-"${REV}" /out/wallpapers/usr/share/wallpapers/Aurora && \
     ln -sr /out/wallpapers/usr/share/backgrounds/aurora/aurora.xml /out/wallpapers/usr/share/backgrounds/default.xml
 
 RUN set -xeuo pipefail && \


### PR DESCRIPTION
```
could not find required directory "images" for package “/usr/share/backgrounds/aurora/aurora-wallpaper-3/contents/* should be QList("images/")
```

tested in a VM from bootc install

breaks plasma-setup on beta branch https://github.com/ublue-os/packages/pull/1222