### PR TITLE
feat: set krunner-bazaar icon size

### DIFF
--- a/system_files/shared/usr/share/ublue-os/flatpak-overrides/io.github.kolunmi.Bazaar
+++ b/system_files/shared/usr/share/ublue-os/flatpak-overrides/io.github.kolunmi.Bazaar
@@ -1,2 +1,5 @@
 [Context]
 filesystems=host-etc
+
+[Environment]
+BAZAAR_DESKTOP_SEARCH_PROVIDER_ICON_SIZE=256


### PR DESCRIPTION
This will be in bazaar 0.7.14+ and will make the icons shown in krunner nice and sharp.

See: https://github.com/bazaar-org/bazaar/pull/1418