### PR TITLE
chore: pin projectbluefin/common to digest

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -82,9 +82,11 @@ RUN set -xeuo pipefail && \
   cp -r /out/system_files/shared/usr/share/plasma/look-and-feel/dev.getaurora.aurora.desktop/contents/splash/ /out/system_files/shared/usr/share/plasma/look-and-feel/dev.getaurora.auroralight.desktop/contents && \
   cp -r /out/system_files/shared/usr/share/plasma/look-and-feel/dev.getaurora.aurora.desktop/contents/layouts /out/system_files/shared/usr/share/plasma/look-and-feel/dev.getaurora.auroralight.desktop/contents
 
+FROM ghcr.io/projectbluefin/common@sha256:0538fbe3da628dbef2b5b60bc4fd9b3f0a40cd4687130aab31d223666b7381f2 AS bluefin
+
 FROM scratch AS ctx
-COPY --from=ghcr.io/projectbluefin/common:latest /system_files/shared /system_files/shared
-COPY --from=ghcr.io/projectbluefin/common:latest /system_files/nvidia /system_files/nvidia
+COPY --from=bluefin /system_files/shared /system_files/shared
+COPY --from=bluefin /system_files/nvidia /system_files/nvidia
 COPY --from=builder /out/wallpapers /wallpapers
 COPY --from=builder /out/logos /logos
 COPY --from=builder /out/system_files/shared /system_files/shared


### PR DESCRIPTION
The idea behind this is that we can deliberately upgrade the things we get from bluefin as some changes on their side require changes here, this will avoid surprises and random breakages in the future. Things have also mostly settled down. These updates are not supposed to blindly automerge here as this would trigger image builds in ublue-os/aurora for things that are not related to anything we care about.

These changes should be carefully vetted and evaluated again. We will not need every single hash bump PR.

related to https://github.com/get-aurora-dev/common/issues/51