### PR TITLE
feat(ci): keyless OIDC signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,7 @@ jobs:
       - name: Sign container image
         if: github.event_name != 'pull_request'
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${TAGS}
+          cosign sign -y ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}


### PR DESCRIPTION
This makes sense to do here as this is not user-facing and will
therefore not break stuff in a meaningful way other than CI. This needs
some changes on the workflows in ublue-os/aurora because we are no
longer signing with static keys.

See: https://docs.sigstore.dev/certificate_authority/oidc-in-fulcio/

We will not always be able to use keyless signing and will need a static
key, the now unused public key should still be accessible as there are
still containers on the registry that got signed by this keypair and we
currently do not have a better place for it other than this repo here.