### PR TITLE
chore(ci): pin action hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@061ffd31bb5c3f8733a6f9bbdf00a9fb02eb708c
         with:
           containerfiles: |
             ./Containerfile
@@ -57,7 +57,7 @@ jobs:
           oci: true
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -66,7 +66,7 @@ jobs:
 
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@3916dcf329473955be3059ef62c9c062ea1b9054
         id: push
         if: github.event_name != 'pull_request'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           notes<<NOTES_EOF
           Monthly snapshot release ${TAG}
 
-          This is an automated monthly snapshot of bluefin-common configuration files.
+          This is an automated monthly snapshot of aurora-common configuration files.
           NOTES_EOF
           EOF
           else
@@ -53,7 +53,7 @@ jobs:
           $(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:'- %s (%h)' --no-merges)
 
           ---
-          *This is an automated monthly snapshot of bluefin-common configuration files.*
+          *This is an automated monthly snapshot of aurora-common configuration files.*
           NOTES_EOF
           EOF
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-dump
+dump*


### PR DESCRIPTION
They haven't made a release in a long time, this would also get rid of the node 20 deprecation errors.