### PR TITLE
feat: set Plasmalogin wallpaper to proper directory

### DIFF
--- a/system_files/shared/usr/lib/plasmalogin/defaults.conf
+++ b/system_files/shared/usr/lib/plasmalogin/defaults.conf
@@ -2,5 +2,5 @@
 WallpaperPlugin=org.kde.image
 
 [Greeter][Wallpaper][org.kde.image][General]
-Image=file:///usr/share/backgrounds/default.jxl
-PreviewImage=file:///usr/share/backgrounds/default.jxl
+Image=file:///usr/share/wallpapers/Aurora/
+PreviewImage=file:///usr/share/wallpapers/Aurora/


### PR DESCRIPTION
This future-proofs it by not hardcoding that specific wallpaper, we might have a dark/light variant in the future.