### PR TITLE
feat: transition users from ptyxis to konsole

### DIFF
--- a/system_files/shared/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/90-aurora-ptyxis-to-konsole.js
+++ b/system_files/shared/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/90-aurora-ptyxis-to-konsole.js
@@ -1,0 +1,24 @@
+// Added in May 2026, TODO: remove this file from the system when most users have ran
+// this migration script
+// https://github.com/ublue-os/aurora/issues/1741
+
+const old_app = "org.gnome.Ptyxis";
+const new_app = "org.kde.konsole";
+
+for (const panel of panels()) {
+    for (const widget of panel.widgets()) {
+        if (widget.type === "org.kde.plasma.icontasks") {
+            widget.currentConfigGroup = ["General"];
+            const launchers = widget.readConfig("launchers").toString();
+
+            if (launchers.includes(old_app)) {
+
+                const re = new RegExp(old_app.replace(/\./g, "\\."), "g");
+                const updated = launchers.replace(re, new_app);
+
+                widget.writeConfig("launchers", updated.split(','));
+                widget.reloadConfig();
+            }
+        }
+    }
+}


### PR DESCRIPTION

feat: transition users from ptyxis to konsole

You can test this by pinning ptyxis on the panel and then running this
script inside `plasma-interactive-console` or upgrade an F43 Aurora
image to an image that has this change.

It should make Ptyxis disappear and konsole should show up instead, this
should make the transition easier as ptyxis won't just vanish with no
replacement when we remove it from the image.

How this is supposed to work can be read on here.
https://develop.kde.org/docs/plasma/scripting/#running-scripts

I did not get this working for the favorites section in the kickoff
widget, so for that ptyxis will just disappear with no replacement, but
at least it will not leave a blank icon behind and will not look as
broken.

This might annoy a small minority of people that have been running the
Beta/Latest stream where ptyxis has been removed already and they have
explicitly installed it again via flatpak. This change is intended to
reach the Stable stream when we flip the switch on F44 on that.

Related: https://github.com/ublue-os/aurora/issues/1741