### PR TITLE
fix: don't show failure message on aurora-cli

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/system.just
+++ b/system_files/shared/usr/share/ublue-os/just/system.just
@@ -32,6 +32,7 @@ benchmark:
 
 # Configure Aurora-CLI Terminal Experience with Brew
 [group('System')]
+[no-exit-message]
 aurora-cli:
     @ublue-bling
     brew bundle --file=/usr/share/ublue-os/homebrew/cli.Brewfile


### PR DESCRIPTION
same as https://github.com/projectbluefin/common/pull/303