### PR TITLE
feat: add a simple uupd config

### DIFF
--- a/system_files/shared/etc/uupd/config.json
+++ b/system_files/shared/etc/uupd/config.json
@@ -1,0 +1,7 @@
+{
+    "modules": {
+        "distrobox": {
+            "disable": true
+        }
+    }
+}


### PR DESCRIPTION
Instead of overriding uupd.service let's just disable Distrobox module globally. Any further additions should be done here.

I've already tested the change in Bazzite (https://github.com/ublue-os/bazzite/pull/4866), works as intended.

https://github.com/ublue-os/uupd#configuration

Related: https://github.com/ublue-os/aurora/pull/2166