### PR TITLE
fix: docker group not being present in DX

### DIFF
--- a/system_files/dx/usr/lib/sysusers.d/docker.conf
+++ b/system_files/dx/usr/lib/sysusers.d/docker.conf
@@ -1,0 +1,6 @@
+# https://github.com/docker/docker-ce-packaging/pull/1195
+# https://github.com/moby/moby/pull/49813
+# FIXME: Why is this not yet in the official package, this has been upstream but is not there for some reason?
+# this should be present in the docker-ce package, check with rpm -ql in the future
+# and remove this file again
+g docker -


### PR DESCRIPTION
I have no idea why exactly the group is missing now.

You can reproduce this by installing from our F43 ISOs, rebasing to DX which happens to be on F44 now and then running `ujust devmode` `ujust dx-group`

I have no idea how this change never made it into a package.

Related:
- https://github.com/docker/docker-ce-packaging/pull/1195
- https://github.com/moby/moby/pull/49813