### PR TITLE
fix: swtpm setup directory not being present

### DIFF
--- a/system_files/dx/usr/lib/tmpfiles.d/swtpm-workaround.conf
+++ b/system_files/dx/usr/lib/tmpfiles.d/swtpm-workaround.conf
@@ -1,0 +1,3 @@
+# https://github.com/ublue-os/aurora/issues/2257
+# TODO: remove me when new swptm v0.10.1+ lands in fedora
+d /var/lib/swtpm-localca 0750 tss tss - -


### PR DESCRIPTION
This causes windows virtual machine creation to break.

follow up of cd7b76f3efb3ab70e55

fixes: https://github.com/ublue-os/aurora/issues/2257