### PR TITLE
chore(renovate): disable alpine digest pin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,5 +39,11 @@
         'ghcr.io/ublue-os/aurora-wallpapers',
       ],
     },
+    {
+      matchDepNames: [
+        'docker.io/library/alpine',
+      ],
+      pinDigests: false,
+    },
   ],
 }


### PR DESCRIPTION
Think we can atleast disable this from renovate trying to pin it