### PR TITLE
feat: disable middle-click-paste by default

### DIFF
--- a/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
+++ b/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
@@ -1,6 +1,7 @@
 [Wayland]
 InputMethod[$e]=/usr/share/applications/com.github.maliit.keyboard.desktop
 VirtualKeyboardEnabled=true
+EnablePrimarySelection=false
 
 [Plugins]
 blurEnabled=true


### PR DESCRIPTION
Fedora already discussed this effort [1] and they made some great points against shipping it by default, even though I use it myself quite often, it should just not be a default on modern systems. I can totally see this change being made in KDE itself in the future.

[1] https://forge.fedoraproject.org/kde/tracker/issues/681

Thoughts?

We should still extensively test this across multiple applications (Electron, GTK, QT, flutter) to make sure it doesn't break anything or causes other unexpected issues if we are going to ship it by default.