### PR TITLE
feat: also disable middle click in firefox

### DIFF
--- a/system_files/shared/usr/share/ublue-os/firefox-config/01-aurora-global.js
+++ b/system_files/shared/usr/share/ublue-os/firefox-config/01-aurora-global.js
@@ -1,3 +1,6 @@
 // Aurora Global
 pref("gfx.webrender.all", true);
 pref("media.hardware-video-decoding.force-enabled", true);
+// Hopefully upstream does this at some point :)
+// https://phabricator.services.mozilla.com/D277804
+pref("middlemouse.paste", true;


### PR DESCRIPTION
I don't know why the desktop doesn't dictate this to applications. We ship firefox by default so we have to change it there as well. This leaves chromium with the bad stock behavior, but we can't really ship configurations for the entirety of flathub.

It will only affect new installations.

Follow up of https://github.com/get-aurora-dev/common/pull/224