### PR TITLE
chore(ci): switch over to zstd again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
           extra-args: |
-            --compression-format=zstd:chunked
+            --compression-format=zstd
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
zstd:chunked is not supported by ghcr is anyway, it only takes more time to push