### PR TITLE
fix: ujust shell completions

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -99,10 +99,8 @@ EOF
 RUN <<EOF
 set -xeuo pipefail
 
-install -d /out/system_files/shared/usr/share/bash-completion/completions /out/system_files/shared/usr/share/zsh/site-functions /out/system_files/shared/usr/share/fish/vendor_completions.d/
-just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > /out/system_files/shared/usr/share/bash-completion/completions/ujust
-just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > /out/system_files/shared/usr/share/zsh/site-functions/_ujust
-just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > /out/system_files/shared/usr/share/fish/vendor_completions.d/ujust.fish
+install -d /out/system_files/shared/usr/share/bash-completion/completions
+JUST_COMPLETE=bash just | sed -E 's/just/ujust/g' > /out/system_files/shared/usr/share/bash-completion/completions/ujust
 EOF
 
 RUN <<EOF

--- a/system_files/shared/usr/bin/ujust
+++ b/system_files/shared/usr/bin/ujust
@@ -1,3 +1,3 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
-just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"
+JUST_JUSTFILE="/usr/share/ublue-os/just/00-entry.just" /usr/bin/just "${@}"

--- a/system_files/shared/usr/share/fish/vendor_conf.d/ujust.fish
+++ b/system_files/shared/usr/share/fish/vendor_conf.d/ujust.fish
@@ -1,0 +1,1 @@
+alias ujust='just --justfile "/usr/share/ublue-os/just/00-entry.just"'

--- a/system_files/shared/usr/share/zsh/site-functions/_ujust
+++ b/system_files/shared/usr/share/zsh/site-functions/_ujust
@@ -1,0 +1,12 @@
+#compdef ujust
+
+_ujust() {
+  # Hardcode justfile arguments into the completion context
+  words=(just --justfile "/usr/share/ublue-os/just/00-entry.just" "${words[@]:1}")
+  (( CURRENT += 2 ))
+
+  # Delegate to just's native completion function
+  _just
+}
+
+_ujust "$@"


### PR DESCRIPTION
Final solution for the new just completion engine ended up being; For `bash` we have to change the script to set `JUST_JUSTFILE` while having an autocomplete script where `just` is substituted to `ujust`. This was based on feedback from Casey in
https://github.com/casey/just/discussions/3683#discussioncomment-17804984

For `fish` the only method i found to get the completions working properly was to alias `ujust` to `just --justfile
"/usr/share/ublue-os/justfile"`

now for zsh i had to write a custom compdef that hardcodes in `--justfile "/usr/share/ublue-os/justfile"` and passes it to the completion definitions for `just`, i do not want to go into how long i spent on this stupid compdef...

Hikari's words, he figured everything out here. It's an exact clone of https://github.com/ublue-os/packages/pull/1319.

resolves: https://github.com/get-aurora-dev/common/issues/220