### PR TITLE
feat(just): use uupd for system upgrades

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -14,12 +14,16 @@ update:
         echo "automatic updates are currently running, use \`journalctl -fexu $SERVICE\` to see logs"
         exit 1
     fi
-    if command -v rpm-ostree >/dev/null 2>&1 && [ -f /etc/rpm-ostreed.conf ] && grep -q -E -e "^[[:space:]]*LockLayering[[:space:]]*=[[:space:]]*true([[:space:]]*(#.*)?)?$" /etc/rpm-ostreed.conf ; then
-        sudo bootc upgrade
-    else
-        rpm-ostree upgrade
-    fi
-    # rpm-ostree used due to bootc upgrade not supporting local layered packages
+
+    # less bad than shell script nightmare to do the whole bootc/rpm-ostree dance
+    pkexec uupd \
+      --hw-check=false \
+      --json \
+      --disable-module-flatpak \
+      --disable-module-brew \
+      --disable-module-distrobox \
+      | jq -r '[(.title, .msg, .description) | select(.)] | join(" ")'
+
     # Updates system Flatpaks
     if flatpak remotes | grep -q system; then
         flatpak update -y


### PR DESCRIPTION
We have a bit of an unideal situation currently as we are rather poorly
re-implementing what uupd already handles in regards to
rpm-ostree/bootc.

What we want is to use bootc for upgrades when it is possible to use it.
We currently don't do this as we just check for the `LockLayering` value
in `rpm-ostreed.conf`. Users don't change this so this will always call
to `rpm-ostree`. This recipe used to be shared with bluefin-lts which
sets `LockLayering=True` because it doesn't support package layering.

This also matches what automatic background updates are doing in this
regard. Which might prevent bugs/confusion in the future.

Bootc upgrade is slightly faster than rpm-ostree and more importantly
does not mess with any RPMs or calls to any repos, which are all steps
that might fail. There have also been bugs in the past in `rpm-ostree`
that broke image updates [1]. Bootc is simpler and the likelihood seems to
be lower for `upgrade` to straight up be broken.

UUPD sadly doens't have "human output" as it wasn't really designed for
this usecase so we need to do a little trickery there.

[1] https://github.com/coreos/rpm-ostree/issues/5567