### PR TITLE
feat(just): use bootc upgrade when possible

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -36,6 +36,8 @@ update:
         sudo bootc upgrade
 
     elif [[ "${IS_OSTREE}" == "true" ]]; then
+      # Without password would be nice
+      # https://github.com/bootc-dev/bootc/issues/409
       STATUS=$(sudo bootc status --json | jq ".status")
 
       STAGED_INCOMPAT=$(echo "${STATUS}" | jq ".staged.incompatible")

--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -18,12 +18,15 @@ update:
         exit 1
     fi
 
-    if grep -q -E "(^|\s)composefs=.*\S" /proc/cmdline; then
-        IS_COMPOSEFS="true"
-        IS_OSTREE="false"
+    if systemd-detect-virt --container -q; then
+      echo "Running inside a container environment, nothing to upgrade"
+      exit 1
+    elif grep -q -E "(^|\s)composefs=.*\S" /proc/cmdline; then
+      IS_COMPOSEFS="true"
+      IS_OSTREE="false"
     elif grep -q -E "(^|\s)ostree=.*\S" /proc/cmdline; then
-        IS_COMPOSEFS="false"
-        IS_OSTREE="true"
+      IS_COMPOSEFS="false"
+      IS_OSTREE="true"
     else
       echo "Not booted, nothing to upgrade."
       exit 1

--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -4,7 +4,10 @@ alias upgrade := update
 
 # Update system, flatpaks and homebrew packages all at once
 update:
-    #!/usr/bin/bash
+    #!/usr/bin/env bash
+
+    set -eou pipefail
+
     if systemctl cat -- uupd.timer &> /dev/null; then
         SERVICE="uupd.service"
     else
@@ -14,12 +17,40 @@ update:
         echo "automatic updates are currently running, use \`journalctl -fexu $SERVICE\` to see logs"
         exit 1
     fi
-    if command -v rpm-ostree >/dev/null 2>&1 && [ -f /etc/rpm-ostreed.conf ] && grep -q -E -e "^[[:space:]]*LockLayering[[:space:]]*=[[:space:]]*true([[:space:]]*(#.*)?)?$" /etc/rpm-ostreed.conf ; then
-        sudo bootc upgrade
+
+    if grep -q -E "(^|\s)composefs=.*\S" /proc/cmdline; then
+        IS_COMPOSEFS="true"
+        IS_OSTREE="false"
+    elif grep -q -E "(^|\s)ostree=.*\S" /proc/cmdline; then
+        IS_COMPOSEFS="false"
+        IS_OSTREE="true"
     else
-        rpm-ostree upgrade
+      echo "Not booted, nothing to upgrade."
+      exit 1
     fi
-    # rpm-ostree used due to bootc upgrade not supporting local layered packages
+
+    if [[ "${IS_COMPOSEFS}" == "true" ]]; then
+        sudo bootc upgrade
+
+    elif [[ "${IS_OSTREE}" == "true" ]]; then
+      STATUS=$(sudo bootc status --json | jq ".status")
+
+      STAGED_INCOMPAT=$(echo "${STATUS}" | jq ".staged.incompatible")
+      BOOTED_INCOMPAT=$(echo "${STATUS}" | jq ".booted.incompatible")
+
+      if [[ "${STAGED_INCOMPAT}" == "true" || ( "${BOOTED_INCOMPAT}" == "true" && -z "${STAGED_INCOMPAT}" ) || "${BOOTED_INCOMPAT}" == "true" ]]; then
+          INCOMPAT="true"
+      else
+          INCOMPAT="false"
+      fi
+
+        if [[ "${INCOMPAT}" == "true" ]]; then
+            rpm-ostree upgrade
+        else
+            sudo bootc upgrade
+        fi
+    fi
+
     # Updates system Flatpaks
     if flatpak remotes | grep -q system; then
         flatpak update -y


### PR DESCRIPTION
The reason why we are not using uupd, which would completely handle the bootc rpm-ostree compatibility dance is because the output is not super useful from a troubleshooting perspective and people like their bling.

What we want is to use bootc for upgrades when it is possible to use it. We currently don't do this as we just check for the `LockLayering` value in `rpm-ostreed.conf`. Users don't change this so this will always call to `rpm-ostree`. We have this because it used to be a shared recipe with bluefin-lts which sets `LockLayering=True` because it doesn't support package layering.

Bootc upgrade is slightly faster than rpm-ostree and more importantly does not mess with any RPMs or calls to any repos, which are all steps that might fail. There have also been bugs in recent times in `rpm-ostree` that broke image updates [1]. Bootc is simpler and the likelihood seems to be lower for `upgrade` to straight up be broken.

The disadvantage compared to always using rpm-ostree for everything is that bootc doesn't have polkit rules to allow members of the wheel group to execute it without authentication, even if rpm-ostree ends up being used which does exactly that.

More complex and probably more buggy alternative to https://github.com/get-aurora-dev/common/pull/252

[1] https://github.com/coreos/rpm-ostree/issues/5567