### PR TITLE
chore: remove flatpak override for vscode

### DIFF
--- a/system_files/shared/etc/skel/.local/share/flatpak/overrides/com.visualstudio.code
+++ b/system_files/shared/etc/skel/.local/share/flatpak/overrides/com.visualstudio.code
@@ -1,3 +1,0 @@
-[Context]
-sockets=wayland;
-filesystems=xdg-run/podman;


### PR DESCRIPTION
We do not support flatpak vscode, either use brew or DX image. Doesn't affect exisitng users anyway.