### PR TITLE
chore: remove qtlogging.ini's

### DIFF
--- a/system_files/shared/usr/share/qt5/qtlogging.ini
+++ b/system_files/shared/usr/share/qt5/qtlogging.ini
@@ -1,6 +1,0 @@
-[Rules]
-*.debug=false
-qt.qpa.xcb.xcberror.warning=false
-kf.svg.info=false
-kf.svg.debug=false
-kf.svg.warning=false

--- a/system_files/shared/usr/share/qt6/qtlogging.ini
+++ b/system_files/shared/usr/share/qt6/qtlogging.ini
@@ -1,6 +1,0 @@
-[Rules]
-*.debug=false
-qt.qpa.xcb.xcberror.warning=false
-kf.svg.info=false
-kf.svg.debug=false
-kf.svg.warning=false


### PR DESCRIPTION
This got added in [1]. We should not override this for all software, we should fix our stuff. Also I'm not sure if this is even relevant anymore.

1: https://github.com/ublue-os/aurora/commit/065b90bdd7fb9ef8210593fb0f94ea2bf8a7b4ff