### PR TITLE
feat(security): bind TPM2 auto-unlock to PCRs 0+7

### DIFF
--- a/system_files/shared/usr/bin/luks-tpm2-autounlock
+++ b/system_files/shared/usr/bin/luks-tpm2-autounlock
@@ -40,6 +40,6 @@ case "${EXIT_CODE}" in
     exit 0
 esac
 
-if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs=0+7 ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
+if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs=0+7+14 ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
   echo "TPM2 LUKS auto-unlock configured for next reboot."
 fi

--- a/system_files/shared/usr/bin/luks-tpm2-autounlock
+++ b/system_files/shared/usr/bin/luks-tpm2-autounlock
@@ -40,6 +40,6 @@ case "${EXIT_CODE}" in
     exit 0
 esac
 
-if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs=0+7+14 ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
+if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs='0+7+14' ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
   echo "TPM2 LUKS auto-unlock configured for next reboot."
 fi

--- a/system_files/shared/usr/bin/luks-tpm2-autounlock
+++ b/system_files/shared/usr/bin/luks-tpm2-autounlock
@@ -40,6 +40,6 @@ case "${EXIT_CODE}" in
     exit 0
 esac
 
-if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs='' ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
+if sudo systemd-cryptenroll --wipe-slot=tpm2 --tpm2-device=auto --tpm2-pcrs=0+7 ${SET_PIN_ARG} "${CRYPT_DISK}" ; then
   echo "TPM2 LUKS auto-unlock configured for next reboot."
 fi


### PR DESCRIPTION
## What changes

Binds TPM2 LUKS auto-unlock in `luks-tpm2-autounlock` to PCRs 0 and 7 (`--tpm2-pcrs=0+7`).

## Why

The script previously passed `--tpm2-pcrs=''`, which bound the LUKS token to no PCRs. With an empty PCR policy, the TPM chip unseals the drive key unconditionally for any software booted on that board.

Binding to `0+7` ensures the TPM checks system integrity before releasing the key:
* PCR 0 validates the core UEFI firmware code.
* PCR 7 validates Secure Boot state and certificates (PK, KEK, db, dbx, shim SBAT).

If Secure Boot is turned off or an unsigned bootloader runs, PCR 7 changes and the TPM hard-locks.

## Threat model and limitations

This is an incremental hardening step, not a complete solution against all physical attacks.

Current Fedora and Universal Blue systems use split boot components: GRUB, a separate initramfs, and a mutable kernel command line. Because these change across updates, binding PCRs 8, 9, 11, or 12 directly is not feasible without breaking unlock on every update.

This leaves specific gaps where combining a PIN with PCRs helps:

* Why PIN alone is insufficient: A PIN stops unauthorized power-ons on clean hardware. However, without PCR binding, an attacker can modify the unencrypted boot partition with a fake prompt or malicious initramfs. The TPM would release the decryption key as soon as the user enters the PIN.
* Why PCRs `0+7` help: When an attacker modifies the boot chain or disables Secure Boot, PCR 7 changes. The TPM refuses to release the key even if the valid PIN is provided.

A full solution for verified passwordless boot requires signed Unified Kernel Images (UKIs) and composefs (as described in the [Fedora Magazine article on sealed atomic desktops](https://fedoramagazine.org/sealed-atomic-desktops-test-images/)). Until UKIs land in standard builds, combining PCRs `0+7` with an optional PIN is the safest baseline available on split boot chains.

## Trade-offs

* PCR 1 is excluded: measuring SMBIOS data and hardware config causes false-positive lockouts on RAM upgrades, dock connections, and standard BIOS setting changes.
* PCR 7 is required: without it (such as using `0+1`), disabling Secure Boot leaves the disk unlock open to unsigned boot media.

## References

* [UAPI Linux TPM PCR Registry](https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/)
* [Sealed Fedora Atomic Desktop bootable container images](https://fedoramagazine.org/sealed-atomic-desktops-test-images/)
