### PR TITLE
fix(just): redirect errors to stdout in update

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/update.just
+++ b/system_files/shared/usr/share/ublue-os/just/update.just
@@ -40,7 +40,7 @@ update:
       # https://github.com/bootc-dev/bootc/issues/409
       # https://github.com/get-aurora-dev/common/issues/270
       # bootc status can might prefix the output from `mount`
-      STATUS=$(sudo bootc status --json | sed -n '/^{/,$p' | jq ".status")
+      STATUS=$(sudo bootc status --json 2> /dev/null | jq ".status")
 
       STAGED_INCOMPAT=$(echo "${STATUS}" | jq ".staged.incompatible")
       BOOTED_INCOMPAT=$(echo "${STATUS}" | jq ".booted.incompatible")


### PR DESCRIPTION
cleaner version of 15117ef2b6f.

This will print it for the user to see and will not mess up the output so jq will be able to parse it